### PR TITLE
fix(lock): Lock objects in the library once they are created

### DIFF
--- a/honeybee_energy_standards/lib/constructions.py
+++ b/honeybee_energy_standards/lib/constructions.py
@@ -37,6 +37,7 @@ def opaque_construction_by_name(construction_name):
 
     # create the Python object from the standards gem dictionary
     _constr_obj = OpaqueConstruction.from_standards_dict(_constr_dict)
+    _constr_obj.lock()
     _idf_opaque_constructions[construction_name] = _constr_obj  # load faster next time
     return _constr_obj
 
@@ -59,5 +60,6 @@ def window_construction_by_name(construction_name):
 
     # create the Python object from the standards gem dictionary
     _constr_obj = WindowConstruction.from_standards_dict(_constr_dict)
+    _constr_obj.lock()
     _idf_window_constructions[construction_name] = _constr_obj  # load faster next time
     return _constr_obj

--- a/honeybee_energy_standards/lib/constructionsets.py
+++ b/honeybee_energy_standards/lib/constructionsets.py
@@ -35,5 +35,6 @@ def construction_set_by_name(construction_set_name):
 
     # create the Python object from the standards gem dictionary
     _c_set_obj = ConstructionSet.from_standards_dict(_c_set_dict)
+    _c_set_obj.lock()
     _json_construction_sets[construction_set_name] = _c_set_obj  # load faster next time
     return _c_set_obj

--- a/honeybee_energy_standards/lib/materials.py
+++ b/honeybee_energy_standards/lib/materials.py
@@ -45,6 +45,7 @@ def opaque_material_by_name(material_name):
     else:
         raise ValueError('Standards gem material type "{}" is not recognized.'.format(
             _mat_dict['material_type']))
+    _mat_obj.lock()
     _idf_opaque_materials[material_name] = _mat_obj  # next time, it will be loaded faster
     return _mat_obj
 
@@ -75,5 +76,6 @@ def window_material_by_name(material_name):
     else:
         raise ValueError('Standards gem material type "{}" is not recognized.'.format(
             _mat_dict['material_type']))
+    _mat_obj.lock()
     _idf_window_materials[material_name] = _mat_obj  # next time, it will be loaded faster
     return _mat_obj

--- a/honeybee_energy_standards/lib/programtypes.py
+++ b/honeybee_energy_standards/lib/programtypes.py
@@ -42,5 +42,6 @@ def program_type_by_name(program_type_name):
 
     # create the Python object from the standards gem dictionary
     _prog_obj = ProgramType.from_standards_dict(_prog_dict)
+    _prog_obj.lock()
     _json_program_types[program_type_name] = _prog_obj  # load faster next time
     return _prog_obj

--- a/honeybee_energy_standards/lib/schedules.py
+++ b/honeybee_energy_standards/lib/schedules.py
@@ -33,5 +33,6 @@ def schedule_by_name(schedule_name):
 
     # create the Python object from the standards gem dictionary
     _sched_obj = ScheduleRuleset.from_standards_dict(_sched_dict)
+    _sched_obj.lock()
     _idf_schedules[schedule_name] = _sched_obj  # load faster next time
     return _sched_obj


### PR DESCRIPTION
We want to avoid the case that someone gets an object from the library and then edits it to be something different than what it was supposed to be.  All editing of the library objects should happen in the source files.

This is a small fix (most lines are for a new test I added) so I will just merge it in.