### PR TITLE
docs(coveralls): Add coveragerc

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+omit = honeybee_energy_standards/_util/*


### PR DESCRIPTION
I realized that I can use this to ignore the utilities used to regenerate the JSONs.