### PR TITLE
Format docstrings for correct display in sphinx-generated bootstrap pages

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,0 +1,40 @@
+/*
+ * bootstrap-sphinx.css
+ * ~~~~~~~~~~~~~~~~~~~~
+ *
+ * Sphinx stylesheet -- Bootstrap theme.
+ */
+
+
+/* The code below is based on the bootstrap website sidebar */
+
+
+/* Show and affix the side nav when space allows it */
+@media screen and (min-width: 992px) {
+  .bs-sidenav .nav > .active > ul {
+    display: block;
+  }
+  /* Widen the fixed sidenav */
+  .bs-sidenav.affix,
+  .bs-sidenav.affix-bottom {
+    width: 292px;
+  }
+  .bs-sidenav.affix {
+    position: fixed; /* Undo the static from mobile first approach */
+  }
+  .bs-sidenav.affix-bottom {
+    position: absolute; /* Undo the static from mobile first approach */
+  }
+  .bs-sidenav.affix-bottom .bs-sidenav,
+  .bs-sidenav.affix .bs-sidenav {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+}
+@media screen and (min-width: 1200px) {
+  /* Widen the fixed sidenav again */
+  .bs-sidenav.affix-bottom,
+  .bs-sidenav.affix {
+    width: 360px;
+  }
+}

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,0 +1,107 @@
+{% extends "basic/layout.html" %}
+
+{% if theme_bootstrap_version == "3" %}
+  {% set bootstrap_version, navbar_version = "3.3.7", "" %}
+  {% set bs_span_prefix = "col-md-" %}
+{% else %}
+  {% set bootstrap_version, navbar_version = "2.3.2", "-2" %}
+  {% set bs_span_prefix = "span" %}
+{% endif %}
+
+{%- set render_sidebar = (not embedded) and (not theme_nosidebar|tobool) and sidebars %}
+
+{%- set bs_content_width = render_sidebar and "8" or "12"%}
+
+{%- block doctype -%}
+<!DOCTYPE html>
+{%- endblock %}
+
+{# Sidebar: Rework into our Bootstrap nav section. #}
+{% macro navBar() %}
+{% include "navbar" + navbar_version + ".html" %}
+{% endmacro %}
+
+{% if theme_bootstrap_version == "3" %}
+  {%- macro bsidebar() %}
+      {%- if render_sidebar %}
+      <div class="{{ bs_span_prefix }}4">
+        <div id="sidebar" class="bs-sidenav" role="complementary">
+          {%- for sidebartemplate in sidebars %}
+            {%- include sidebartemplate %}
+          {%- endfor %}
+        </div>
+      </div>
+      {%- endif %}
+  {%- endmacro %}
+{% else %}
+  {%- macro bsidebar() %}
+      {%- if render_sidebar %}
+      <div class="{{ bs_span_prefix }}4">
+        <div id="sidebar" class="bs-sidenav well" data-spy="affix">
+          {%- for sidebartemplate in sidebars %}
+            {%- include sidebartemplate %}
+          {%- endfor %}
+        </div>
+      </div>
+      {%- endif %}
+  {%- endmacro %}
+{% endif %}
+
+{%- block extrahead %}
+<meta charset='utf-8'>
+<meta http-equiv='X-UA-Compatible' content='IE=edge,chrome=1'>
+<meta name='viewport' content='width=device-width, initial-scale=1.0, maximum-scale=1'>
+<meta name="apple-mobile-web-app-capable" content="yes">
+<script type="text/javascript" src="{{ pathto('_static/js/jquery-1.11.0.min.js', 1) }} "></script>
+<script type="text/javascript" src="{{ pathto('_static/js/jquery-fix.js', 1) }} "></script>
+<script type="text/javascript" src="{{ pathto('_static', 1) + '/bootstrap-' + bootstrap_version + '/js/bootstrap.min.js' }} "></script>
+<script type="text/javascript" src="{{ pathto('_static/bootstrap-sphinx.js', 1) }} "></script>
+{% endblock %}
+
+{# Silence the sidebar's, relbar's #}
+{% block header %}{% endblock %}
+{% block relbar1 %}{% endblock %}
+{% block relbar2 %}{% endblock %}
+{% block sidebarsourcelink %}{% endblock %}
+
+{%- block content %}
+{{ navBar() }}
+<div class="container">
+  <div class="row">
+    {%- block sidebar1 %}{{ bsidebar() }}{% endblock %}
+    <div class="body {{ bs_span_prefix }}{{ bs_content_width }} content" role="main">
+      {% block body %}{% endblock %}
+    </div>
+    {% block sidebar2 %} {# possible location for sidebar #} {% endblock %}
+  </div>
+</div>
+{%- endblock %}
+
+{%- block footer %}
+<footer class="footer">
+  <div class="container">
+    <p class="pull-right">
+      <a href="#">Back to top</a>
+      {% if theme_source_link_position == "footer" %}
+        <br/>
+        {% include "sourcelink.html" %}
+      {% endif %}
+    </p>
+    <p>
+    {%- if show_copyright %}
+      {%- if hasdoc('copyright') %}
+        {% trans path=pathto('copyright'), copyright=copyright|e %}&copy; <a href="{{ path }}">Copyright</a> {{ copyright }}.{% endtrans %}<br/>
+      {%- else %}
+        {% trans copyright=copyright|e %}&copy; Copyright {{ copyright }}.{% endtrans %}<br/>
+      {%- endif %}
+    {%- endif %}
+    {%- if last_updated %}
+      {% trans last_updated=last_updated|e %}Last updated on {{ last_updated }}.{% endtrans %}<br/>
+    {%- endif %}
+    {%- if show_sphinx %}
+      {% trans sphinx_version=sphinx_version|e %}Created using <a href="http://sphinx-doc.org/">Sphinx</a> {{ sphinx_version }}.{% endtrans %}<br/>
+    {%- endif %}
+    </p>
+  </div>
+</footer>
+{%- endblock %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,8 +48,8 @@ extensions = [
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
     'sphinx.ext.githubpages',
-	'sphinxcontrib.fulltoc',
-	'sphinx.ext.napoleon'
+    'sphinxcontrib.fulltoc',
+    'sphinx.ext.napoleon'
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -101,11 +101,17 @@ html_theme_options = {
     # Fix navigation bar to top of page?
     # Values: "true" (default) or "false"
     'navbar_fixed_top': "true",
-	'navbar_pagenav': True,
+    'navbar_pagenav': True,
     'source_link_position': "nav",
-	'bootswatch_theme': "united",
+    'bootswatch_theme': "united",
     'bootstrap_version': "3",
-	}
+}
+
+# Bootstrap theme custom file paths (relative to this file)
+# Layout.html path (already added above, include if different)
+# templates_path = ['_templates']
+# Stylesheet path
+html_static_path = ["_static"]
 
 # on_rtd is whether we are on readthedocs.org
 # on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
@@ -217,3 +223,21 @@ epub_exclude_files = ['search.html']
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
+
+# -- Options for autodoc extension --------------------------------------------
+autodoc_default_options = {
+    'inherited-members': True,
+}
+
+autodoc_member_order = 'groupwise'
+
+
+def setup(app):
+    """Run custom code with access to the Sphinx application object
+
+    Args:
+        app: the Sphinx application object
+    """
+
+    # Add bootstrap theme custom stylesheet
+    app.add_stylesheet("custom.css")

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
 Welcome to honeybee-energy-standards's documentation!
-===================================
+=====================================================
 
 .. toctree::
    :maxdepth: 2

--- a/honeybee_energy_standards/_util/_construction.py
+++ b/honeybee_energy_standards/_util/_construction.py
@@ -8,31 +8,35 @@ def clean_constructions(source_filename, dest_directory):
     """Process the OpenStudio Standards Construction dictionary and write a clean version.
 
     Specifically, this method performs the following cleaning operations:
-        * Output resulting dictionary in a format with the name of the Construction
-            as the key and the dictionary of the construction properties as the values.
-        * Remove keys from the construction that are not used by honeybee including:
-            'insulation_layer', 'standards_construction_type', 'skylight_framing'.
-        * Discount odd constructions that are not generally applicable but are intsead
-            specific to a DoE reference building. (eg. 'LargeHotel Interior Ceiling')
-        * Remove the few constructions that do not have supporting materials in the
-            nearby material.json. Note that this removal will not be performed if there
-            is no neightboring material.json next to where the constructions.json will
-            be output.
+
+    * Output resulting dictionary in a format with the name of the Construction
+        as the key and the dictionary of the construction properties as the values.
+    * Remove keys from the construction that are not used by honeybee including:
+        'insulation_layer', 'standards_construction_type', 'skylight_framing'.
+    * Discount odd constructions that are not generally applicable but are intsead
+        specific to a DoE reference building. (eg. 'LargeHotel Interior Ceiling')
+    * Remove the few constructions that do not have supporting materials in the
+        nearby material.json. Note that this removal will not be performed if there
+        is no neightboring material.json next to where the constructions.json will
+        be output.
 
     Args:
         source_filename: The full path to the construction JSON in the OpenStudio
             standards gem. If the standards gem repo has been downloaded to one's
             machine this file is likely in a location like the following:
-                C:/Users/[USERNAME]/Documents/GitHub/openstudio-standards/lib/
-                openstudio-standards/standards/ashrae_90_1/data/ashrae_90_1.constructions.json
+                C:/Users/[USERNAME]/Documents/GitHub/openstudio-standards/lib/\
+openstudio-standards/standards/ashrae_90_1/data/ashrae_90_1.constructions.json
         dest_directory: The destination directory into which clean JSONs will be written.
             If you are trying to update the files within the honeybee_standards repo,
             you likely want to write to the following location:
                 C:/Users/[USERNAME]/Documents/GitHub/honeybee-standards/honeybee_standards/data/
 
     Returns:
-        opaque_dest_file_path: The file path to the clean JSON with opaque materials.
-        window_dest_file_path: The file path to the clean JSON with window materials.
+        A tuple with two elements
+
+        -   opaque_dest_file_path -- The file path to the clean JSON with opaque materials.
+
+        -   window_dest_file_path: The file path to the clean JSON with window materials.
     """
     # list all edits to be made from the original file
     _remove_keys = ('insulation_layer', 'standards_construction_type', 'skylight_framing')

--- a/honeybee_energy_standards/_util/_construction_set.py
+++ b/honeybee_energy_standards/_util/_construction_set.py
@@ -12,11 +12,15 @@ def clean_construction_sets(source_filename, dest_directory, vintage,
     """Clean the OpenStudio Standards Construction Properties dictionary.
 
     Specifically, this method performs the following major cleaning operations:
+
     * Classify the individual construction properties into complete ConstructionSets
         oranized by Climate Zone and Construction Type. These include:
-            * climate zones: (1, 2, 3, 4, 5, 6, 7, 8)
-            * construction types: ('SteelFramed', 'WoodFramed', 'Mass', 'MetalBuilding')
+
+        * climate zones: (1, 2, 3, 4, 5, 6, 7, 8)
+        * construction types: ('SteelFramed', 'WoodFramed', 'Mass', 'MetalBuilding'
+
         This entails the following default assumptions:
+
             * When multiple constructions exist for a given construction type, this
                 method will default to the NonResidential building type and ignore
                 the Residential and Semiheated building types.
@@ -33,6 +37,7 @@ def clean_construction_sets(source_filename, dest_directory, vintage,
                 or 'Without Curb'.
             * When multiple variations of a given climate zone number exist for a given
                 zone (ie. 3A, 3B, 3C) prefernce will be given to A.
+
     * Output resulting dictionary in a format with the name of the ConstructionSet
         as the key and the dictionary of the constructions as the values.
 
@@ -40,13 +45,13 @@ def clean_construction_sets(source_filename, dest_directory, vintage,
         source_filename: The full path to the construction properties JSON in the
             OpenStudio standards gem. If the standards gem repo has been downloaded
             to one's machine this file is likely in a location like the following:
-                C:/Users/[USERNAME]/Documents/GitHub/openstudio-standards/lib/
-                openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2013/data/
-                ashrae_90_1_2013.construction_properties.json
+                C:/Users/[USERNAME]/Documents/GitHub/openstudio-standards/lib/\
+openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2013/data/\
+ashrae_90_1_2013.construction_properties.json
         dest_directory: The destination directory into which clean JSONs will be written.
             If you are trying to update the files within the honeybee_standards repo,
             you likely want to write to the following location:
-                C:/Users/[USERNAME]/Documents/GitHub/honeybee-standards/honeybee_standards/
+                C:/Users/[USERNAME]/Documents/GitHub/honeybee-standards/honeybee_standards/\
                 data/construction_set
         vintage: Text for the vintage of the data to which the space types correspond to.
             Typically, this should be a shortened version of the full name of a standard.
@@ -58,7 +63,7 @@ def clean_construction_sets(source_filename, dest_directory, vintage,
             will be used to determin target resistances
 
     Returns:
-        dest_file_path: The file path to the clean JSON.
+        dest_file_path -- The file path to the clean JSON.
     """
     # initialize the clean dictionary
     constr_set_dict = {}

--- a/honeybee_energy_standards/_util/_material.py
+++ b/honeybee_energy_standards/_util/_material.py
@@ -8,6 +8,7 @@ def clean_materials(source_filename, dest_directory):
     """Process the OpenStudio Standards Material dictionary and write out a clean version.
 
     Specifically, this method performs the following cleaning operations:
+
         * Output resulting dictionary in a format with the name of the Material
             as the key and the dictionary of the material properties as the values.
         * Remove all material properties with None values. This reduces the file size
@@ -24,16 +25,19 @@ def clean_materials(source_filename, dest_directory):
         source_filename: The full path to the material JSON in the OpenStudio
             standards gem. If the standards gem repo has been downloaded to one's
             machine this file is likely in a location like the following:
-                C:/Users/[USERNAME]/Documents/GitHub/openstudio-standards/lib/
-                openstudio-standards/standards/ashrae_90_1/data/ashrae_90_1.materials.json
+                C:/Users/[USERNAME]/Documents/GitHub/openstudio-standards/lib/\
+openstudio-standards/standards/ashrae_90_1/data/ashrae_90_1.materials.json
         dest_directory: The destination directory into which clean JSONs will be written.
             If you are trying to update the files within the honeybee_standards repo,
             you likely want to write to the following location:
                 C:/Users/[USERNAME]/Documents/GitHub/honeybee-standards/honeybee_standards/data/
 
     Returns:
-        opaque_dest_file_path: The file path to the clean JSON with opaque materials.
-        window_dest_file_path: The file path to the clean JSON with window materials.
+        A tuple with two elements
+
+        -   opaque_dest_file_path: The file path to the clean JSON with opaque materials.
+
+        -   window_dest_file_path: The file path to the clean JSON with window materials.
     """
     # types of materials (to help organize opaque materials from window ones)
     opaque_types = ('StandardOpaqueMaterial', 'MasslessOpaqueMaterial', 'AirGap')

--- a/honeybee_energy_standards/_util/_program_type.py
+++ b/honeybee_energy_standards/_util/_program_type.py
@@ -8,34 +8,38 @@ def clean_space_types(source_filename, dest_directory, vintage):
     """Process an OpenStudio Standards Space Type dictionary and write out a clean version.
 
     Specifically, this method performs 3 cleaning operations:
-        * Discount odd space types that are not generally applicable but are intsead
-            specific to a particular DoE reference building. (eg. 'Apartment_topfloor_NS')
-        * Rename space types that use naming conventions that are not consistent with the
-            other space types (eg. 'Courthouse - Conference' instead of 'Conference')
-        * Reorganizing the 'Office' building type to be 3 separate types:
-            'LargeOffice', 'MediumOffice', 'SmallOffice'.
+
+    * Discount odd space types that are not generally applicable but are intsead
+        specific to a particular DoE reference building. (eg. 'Apartment_topfloor_NS')
+    * Rename space types that use naming conventions that are not consistent with the
+        other space types (eg. 'Courthouse - Conference' instead of 'Conference')
+    * Reorganizing the 'Office' building type to be 3 separate types:
+        'LargeOffice', 'MediumOffice', 'SmallOffice'.
 
     Args:
         source_filename: The full path to the space type JSON in the OpenStudio
             standards gem. If the standards gem repo has been downloaded to
             one's machine this file is likely in a location like the following:
-                C:/Users/[USERNAME]/Documents/GitHub/openstudio-standards/lib/
-                openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2013/data/
+                C:/Users/[USERNAME]/Documents/GitHub/openstudio-standards/lib/\
+                openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2013/data/\
                 ashrae_90_1_2013.spc_typ.json
         dest_directory: The destination directory into which clean JSONs will be written.
             If you are trying to update the files within the honeybee_standards repo,
             you likely want to write to the following location:
-                C:/Users/[USERNAME]/Documents/GitHub/honeybee-standards/honeybee_standards/
+                C:/Users/[USERNAME]/Documents/GitHub/honeybee-standards/honeybee_standards/\
                 data/program_type/
         vintage: Text for the vintage of the data to which the space types correspond to.
             Typically, this should be a shortened version of the full name of a standard.
             (eg. '2013' for 'Ashrae 90.1 2013')
 
     Returns:
-        program_type_registry: Path to a JSON file containing the final included
+        A tuple with two elements
+
+        -   program_type_registry: Path to a JSON file containing the final included
             ProgramType names organized by building type. This is meant to be a
             human-readable file that documents all ProgramTypes that are available.
-        program_type: Path to a JSON file containing the cleaned JSON with all relevant
+
+        -   program_type: Path to a JSON file containing the cleaned JSON with all relevant
             data. Each ProgramType has the clean, unique ProgramType name as a key and
             the value is the dictionary representation of all the ProgramType data.
     """
@@ -157,6 +161,7 @@ def clean_individual_type(vintage, building_type, space_type, data):
     """Clean the dictionary of an individual space type.
 
     Specifically, this method performs 2 cleaning operations:
+
     * Replacing the name of the dictionary with a unique name.
     * Removing all None values from the dictionary.
 
@@ -167,8 +172,11 @@ def clean_individual_type(vintage, building_type, space_type, data):
         data: JSON data for the space type.
 
     Return:
-        unique_name: The new unique name for the ProgramType.
-        clean_data: A clean dictionary.
+        A tuple with two elements
+
+        -   unique_name: The new unique name for the ProgramType.
+
+        -   clean_data: A clean dictionary.
     """
     unique_name = '{}::{}::{}'.format(vintage, building_type, space_type)
     clean_data = {'building_type': building_type,

--- a/honeybee_energy_standards/_util/_schedule.py
+++ b/honeybee_energy_standards/_util/_schedule.py
@@ -10,23 +10,24 @@ def clean_schedules(source_filename, dest_directory):
     """Process the OpenStudio Standards Schedule dictionary and write out a clean version.
 
     Specifically, this method performs 3 cleaning operations:
-        * Output resulting dictionary in a format with the name of the ScheduleRuleset
-            as the key and a list of the relevant ScheduleDay dictionaries as values.
-        * Remove meaningless Hour:Minute:Second from the dates over which to apply
-            individual schedule rules and remove the year as well.
-        * Fix schedule values lists that do not have the correct number of values (this
-            should be either 1 or 24 but some appear to have 2).
-        * Remove all 'DummySmrDsn' and 'DummrySmrDsn' rules (I think the second one might
-            be a typo but there's one in the gem now).
-        * Fix the 'WtrDsn' typo (it should be 'WntrDsn' like all of the other schedules).
-        * Un-indent lists of schedule day values, which results in better readability and
-            a significantly smaller file size.
+
+    * Output resulting dictionary in a format with the name of the ScheduleRuleset
+        as the key and a list of the relevant ScheduleDay dictionaries as values.
+    * Remove meaningless Hour:Minute:Second from the dates over which to apply
+        individual schedule rules and remove the year as well.
+    * Fix schedule values lists that do not have the correct number of values (this
+        should be either 1 or 24 but some appear to have 2).
+    * Remove all 'DummySmrDsn' and 'DummrySmrDsn' rules (I think the second one might
+        be a typo but there's one in the gem now).
+    * Fix the 'WtrDsn' typo (it should be 'WntrDsn' like all of the other schedules).
+    * Un-indent lists of schedule day values, which results in better readability and
+        a significantly smaller file size.
 
     Args:
         source_filename: The full path to the schedule JSON in the OpenStudio
             standards gem. If the standards gem repo has been downloaded to one's
             machine this file is likely in a location like the following:
-                C:/Users/[USERNAME]/Documents/GitHub/openstudio-standards/lib/
+                C:/Users/[USERNAME]/Documents/GitHub/openstudio-standards/lib/\
                 openstudio-standards/standards/ashrae_90_1/data/ashrae_90_1.schedules.json
         dest_directory: The destination directory into which clean JSONs will be written.
             If you are trying to update the files within the honeybee_standards repo,
@@ -34,7 +35,7 @@ def clean_schedules(source_filename, dest_directory):
                 C:/Users/[USERNAME]/Documents/GitHub/honeybee-standards/honeybee_standards/data/
 
     Returns:
-        dest_file_path: The file path to the clean JSON.
+        dest_file_path -- The file path to the clean JSON.
     """
     # list of all the day types to remove
     _remove_day_types = ('DummySmrDsn', 'DummrySmrDsn')


### PR DESCRIPTION
Hi @chriswmackey 
I think this was a very easy one, looks like you've been documenting the docstrings following the new format, thanks for that! The only flies I edited were under the _util folder which I realized are not part of the documentation.
Feel free to check it out and please let me know if you have any comments. 
