### PR TITLE
fix(dependabot): Use >= operator for honeybee-energy version

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,8 @@
+version: 1
+update_configs:
+  - package_manager: "python"
+    directory: "/"
+    update_schedule: "daily"
+    ignored_updates:
+      - match:
+          dependency_name: "honeybee-energy"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-honeybee-energy==1.41.8
+honeybee-energy>=1.41.9


### PR DESCRIPTION
It is very rare that we need a new release of this repo. Only specific edits to the schema of materials, constructions, constructionsets, schedules, or program types should merit a new release.

So I am switching this repo to use >= operators for it's honeybee-energy dependency and telling dependabot to not send a new PR whenever there is a release of honeybee-energy.