### PR TITLE
fix(deps): Move honeybee-energy to dev-requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ python:
 
 install:
   - pip install -r dev-requirements.txt
-  - pip install -r requirements.txt
 
 script:
   - python -m pytest tests/
@@ -22,7 +21,6 @@ jobs:
     - "3.7"
     install:
     - pip install -r dev-requirements.txt
-    - pip install -r requirements.txt
     - npm install @semantic-release/exec
     script:
     - git config --global user.email "releases@ladybug.tools"

--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ git clone https://github.com/ladybug-tools/honeybee-energy-standards
 ```console
 cd honeybee-energy-standards
 pip install -r dev-requirements.txt
-pip install -r requirements.txt
 ```
 
 3. Run Tests:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,4 @@
+honeybee-energy>=1.49.0
 pytest==4.6.9;python_version<'3.0'
 pytest==5.4.3;python_version>='3.6'
 pytest-cov==2.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-honeybee-energy>=1.49.0

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,6 @@ import setuptools
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-with open('requirements.txt') as f:
-    requirements = f.read().splitlines()
-
 setuptools.setup(
     name="honeybee-energy-standards",
     use_scm_version=True,
@@ -18,7 +15,6 @@ setuptools.setup(
     url="https://github.com/ladybug-tools/honeybee-energy-standards",
     packages=setuptools.find_packages(exclude=["tests", "standards_update*"]),
     include_package_data=True,
-    install_requires=requirements,
     classifiers=[
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.6",


### PR DESCRIPTION
Otherwise, we will get all of the dependency tree down to ladybug-geometry when we install in the resources/standards folder. I think we will just have to say that this repo only uses honeybee-energy for tests and, because ti's only data now, it doesn't require any version of honeybee-energy to run.