### PR TITLE
fix(docs): Trigger release of new pacakge

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ own extensions for the library of standards accessible to honeybee_energy. For s
 developers, it is important to know the rules that must be followed to have a
 successful honeybee energy standards extension. First, any honeybee energy standards
 extension must have a package name the starts with `honeybee_energy` and ends
-with `standards` (all words in between are up to the user).
+with `standards` (all words in between are up to the user, barring spaces and
+special characters).
 
 Second, the following folders *MUST* be included in any honeybee energy standards
 extension:

--- a/honeybee_energy_standards/__init__.py
+++ b/honeybee_energy_standards/__init__.py
@@ -1,1 +1,5 @@
-"""honeybee-energy-standards library."""
+"""Honeybee-energy extension for standards, codes, and templates.
+
+Note this package contains no Python code and only contains JSON objects that
+can be consumed by the honeybee-energy package when installed.
+"""


### PR DESCRIPTION
This is the only library that isn't tightly bound to the dependency tree so we need to manually trigger a new release.