### PR TITLE
fix(material): Remove illegal opaque material

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: set up node  # we need node for for semantic release
         uses: actions/setup-node@v2.1.2
         with:
-          node-version: 14.2.0
+          node-version: 14.17.0
       - name: install python dependencies
         run: |
           python -m pip install --upgrade pip
@@ -50,8 +50,8 @@ jobs:
       - name: run semantic release
         id: new_release
         run: |
-          nextRelease="`npx semantic-release --dryRun | grep -oP 'Published release \K.*? ' || true`"
-          npx semantic-release
+          nextRelease="`npx semantic-release@^17.0.0 --dryRun | grep -oP 'Published release \K.*? ' || true`"
+          npx semantic-release@^17.0.0
           echo "::set-output name=tag::$nextRelease"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/honeybee_energy_standards/constructions/opaque_material.json
+++ b/honeybee_energy_standards/constructions/opaque_material.json
@@ -539,18 +539,6 @@
     "solar_absorptance": 0.7,
     "visible_absorptance": 0.8
   },
-  "Interior Wall Addi Insul": {
-    "type": "EnergyMaterial",
-    "identifier": "Interior Wall Addi Insul",
-    "roughness": "MediumRough",
-    "thickness": 2.540005148920944e-08,
-    "conductivity": 0.04323107096585415,
-    "density": 22.425885365668197,
-    "specific_heat": 836.2604510890168,
-    "thermal_absorptance": 0.9,
-    "solar_absorptance": 0.7,
-    "visible_absorptance": 0.7
-  },
   "M01 100mm brick": {
     "type": "EnergyMaterial",
     "identifier": "M01 100mm brick",

--- a/standards_update/_util/_material.py
+++ b/standards_update/_util/_material.py
@@ -52,8 +52,11 @@ openstudio-standards/standards/ashrae_90_1/data/ashrae_90_1.materials.json
         data_store = json.load(f)
 
     # clean the data
+    ignored_materials = {'Interior Wall Addi Insul'}
     for mat in data_store['materials']:
         clean_mat = {}
+        if mat['name'] in ignored_materials:
+            continue
         if mat['notes'] is None and not mat['name'].startswith('Skylight_Frame_Width'):
             for key, value in mat.items():
                 if value is not None:

--- a/tests/material_window_test.py
+++ b/tests/material_window_test.py
@@ -1,7 +1,8 @@
 # coding=utf-8
 from honeybee_energy.material.glazing import EnergyWindowMaterialGlazing, \
     EnergyWindowMaterialSimpleGlazSys
-from honeybee_energy.material.gas import EnergyWindowMaterialGas
+from honeybee_energy.material.gas import EnergyWindowMaterialGas, \
+    EnergyWindowMaterialGasMixture
 import honeybee_energy.lib.materials as mat_lib
 
 import pytest
@@ -10,7 +11,7 @@ import pytest
 def test_material_lib():
     """Test that the honeybee-energy lib has been extended with new material data."""
     possible_types = (EnergyWindowMaterialGlazing, EnergyWindowMaterialSimpleGlazSys,
-                      EnergyWindowMaterialGas)
+                      EnergyWindowMaterialGas, EnergyWindowMaterialGasMixture)
 
     assert len(mat_lib.WINDOW_MATERIALS) > 4  # should now have many more materials
 
@@ -24,7 +25,7 @@ def test_material_lib():
 def test_window_material_by_identifier():
     """Test that all of the materials in the library can be loaded by identifier."""
     possible_types = (EnergyWindowMaterialGlazing, EnergyWindowMaterialSimpleGlazSys,
-                      EnergyWindowMaterialGas)
+                      EnergyWindowMaterialGas, EnergyWindowMaterialGasMixture)
 
     for mat in mat_lib.WINDOW_MATERIALS:
         mat_from_lib = mat_lib.window_material_by_identifier(mat)


### PR DESCRIPTION
It seems that there's a material in openstudio-standards that is never meant to be simulated as-is. This commit removes it from the library.