### PR TITLE
fix(data): Ensure U-values for ASHRAE 90.1 2019 are correct

### DIFF
--- a/honeybee_energy_standards/constructionsets/2016_data.json
+++ b/honeybee_energy_standards/constructionsets/2016_data.json
@@ -18,9 +18,9 @@
     },
     "aperture_set": {
       "type": "ApertureConstructionSetAbridged",
-      "window_construction": "U 1.1 SHGC 0.25 Simple Glazing Window",
+      "window_construction": "U 0.57 SHGC 0.25 Simple Glazing Window",
       "skylight_construction": "U 0.75 SHGC 0.55 Simple Glazing Skylight",
-      "operable_construction": "U 1.1 SHGC 0.25 Simple Glazing Window"
+      "operable_construction": "U 0.57 SHGC 0.25 Simple Glazing Window"
     },
     "door_set": {
       "type": "DoorConstructionSetAbridged",
@@ -78,9 +78,9 @@
     },
     "aperture_set": {
       "type": "ApertureConstructionSetAbridged",
-      "window_construction": "U 1.1 SHGC 0.25 Simple Glazing Window",
+      "window_construction": "U 0.57 SHGC 0.25 Simple Glazing Window",
       "skylight_construction": "U 0.75 SHGC 0.55 Simple Glazing Skylight",
-      "operable_construction": "U 1.1 SHGC 0.25 Simple Glazing Window"
+      "operable_construction": "U 0.57 SHGC 0.25 Simple Glazing Window"
     },
     "door_set": {
       "type": "DoorConstructionSetAbridged",
@@ -108,9 +108,9 @@
     },
     "aperture_set": {
       "type": "ApertureConstructionSetAbridged",
-      "window_construction": "U 1.1 SHGC 0.25 Simple Glazing Window",
+      "window_construction": "U 0.57 SHGC 0.25 Simple Glazing Window",
       "skylight_construction": "U 0.75 SHGC 0.55 Simple Glazing Skylight",
-      "operable_construction": "U 1.1 SHGC 0.25 Simple Glazing Window"
+      "operable_construction": "U 0.57 SHGC 0.25 Simple Glazing Window"
     },
     "door_set": {
       "type": "DoorConstructionSetAbridged",
@@ -138,9 +138,9 @@
     },
     "aperture_set": {
       "type": "ApertureConstructionSetAbridged",
-      "window_construction": "U 0.83 SHGC 0.25 Simple Glazing Window",
+      "window_construction": "U 0.54 SHGC 0.25 Simple Glazing Window",
       "skylight_construction": "U 0.65 SHGC 0.55 Simple Glazing Skylight",
-      "operable_construction": "U 0.83 SHGC 0.25 Simple Glazing Window"
+      "operable_construction": "U 0.54 SHGC 0.25 Simple Glazing Window"
     },
     "door_set": {
       "type": "DoorConstructionSetAbridged",
@@ -198,9 +198,9 @@
     },
     "aperture_set": {
       "type": "ApertureConstructionSetAbridged",
-      "window_construction": "U 0.83 SHGC 0.25 Simple Glazing Window",
+      "window_construction": "U 0.54 SHGC 0.25 Simple Glazing Window",
       "skylight_construction": "U 0.65 SHGC 0.55 Simple Glazing Skylight",
-      "operable_construction": "U 0.83 SHGC 0.25 Simple Glazing Window"
+      "operable_construction": "U 0.54 SHGC 0.25 Simple Glazing Window"
     },
     "door_set": {
       "type": "DoorConstructionSetAbridged",
@@ -228,9 +228,9 @@
     },
     "aperture_set": {
       "type": "ApertureConstructionSetAbridged",
-      "window_construction": "U 0.83 SHGC 0.25 Simple Glazing Window",
+      "window_construction": "U 0.54 SHGC 0.25 Simple Glazing Window",
       "skylight_construction": "U 0.65 SHGC 0.55 Simple Glazing Skylight",
-      "operable_construction": "U 0.83 SHGC 0.25 Simple Glazing Window"
+      "operable_construction": "U 0.54 SHGC 0.25 Simple Glazing Window"
     },
     "door_set": {
       "type": "DoorConstructionSetAbridged",
@@ -258,9 +258,9 @@
     },
     "aperture_set": {
       "type": "ApertureConstructionSetAbridged",
-      "window_construction": "U 0.77 SHGC 0.25 Simple Glazing Window",
+      "window_construction": "U 0.45 SHGC 0.25 Simple Glazing Window",
       "skylight_construction": "U 0.55 SHGC 0.64 Simple Glazing Skylight",
-      "operable_construction": "U 0.77 SHGC 0.25 Simple Glazing Window"
+      "operable_construction": "U 0.45 SHGC 0.25 Simple Glazing Window"
     },
     "door_set": {
       "type": "DoorConstructionSetAbridged",
@@ -318,9 +318,9 @@
     },
     "aperture_set": {
       "type": "ApertureConstructionSetAbridged",
-      "window_construction": "U 0.77 SHGC 0.25 Simple Glazing Window",
+      "window_construction": "U 0.45 SHGC 0.25 Simple Glazing Window",
       "skylight_construction": "U 0.55 SHGC 0.64 Simple Glazing Skylight",
-      "operable_construction": "U 0.77 SHGC 0.25 Simple Glazing Window"
+      "operable_construction": "U 0.45 SHGC 0.25 Simple Glazing Window"
     },
     "door_set": {
       "type": "DoorConstructionSetAbridged",
@@ -348,9 +348,9 @@
     },
     "aperture_set": {
       "type": "ApertureConstructionSetAbridged",
-      "window_construction": "U 0.77 SHGC 0.25 Simple Glazing Window",
+      "window_construction": "U 0.45 SHGC 0.25 Simple Glazing Window",
       "skylight_construction": "U 0.55 SHGC 0.64 Simple Glazing Skylight",
-      "operable_construction": "U 0.77 SHGC 0.25 Simple Glazing Window"
+      "operable_construction": "U 0.45 SHGC 0.25 Simple Glazing Window"
     },
     "door_set": {
       "type": "DoorConstructionSetAbridged",
@@ -378,9 +378,9 @@
     },
     "aperture_set": {
       "type": "ApertureConstructionSetAbridged",
-      "window_construction": "U 0.68 SHGC 0.36 Simple Glazing Window",
+      "window_construction": "U 0.38 SHGC 0.36 Simple Glazing Window",
       "skylight_construction": "U 0.5 SHGC 0.55 Simple Glazing Skylight",
-      "operable_construction": "U 0.68 SHGC 0.36 Simple Glazing Window"
+      "operable_construction": "U 0.38 SHGC 0.36 Simple Glazing Window"
     },
     "door_set": {
       "type": "DoorConstructionSetAbridged",
@@ -438,9 +438,9 @@
     },
     "aperture_set": {
       "type": "ApertureConstructionSetAbridged",
-      "window_construction": "U 0.68 SHGC 0.36 Simple Glazing Window",
+      "window_construction": "U 0.38 SHGC 0.36 Simple Glazing Window",
       "skylight_construction": "U 0.5 SHGC 0.55 Simple Glazing Skylight",
-      "operable_construction": "U 0.68 SHGC 0.36 Simple Glazing Window"
+      "operable_construction": "U 0.38 SHGC 0.36 Simple Glazing Window"
     },
     "door_set": {
       "type": "DoorConstructionSetAbridged",
@@ -468,9 +468,9 @@
     },
     "aperture_set": {
       "type": "ApertureConstructionSetAbridged",
-      "window_construction": "U 0.68 SHGC 0.36 Simple Glazing Window",
+      "window_construction": "U 0.38 SHGC 0.36 Simple Glazing Window",
       "skylight_construction": "U 0.5 SHGC 0.55 Simple Glazing Skylight",
-      "operable_construction": "U 0.68 SHGC 0.36 Simple Glazing Window"
+      "operable_construction": "U 0.38 SHGC 0.36 Simple Glazing Window"
     },
     "door_set": {
       "type": "DoorConstructionSetAbridged",
@@ -498,9 +498,9 @@
     },
     "aperture_set": {
       "type": "ApertureConstructionSetAbridged",
-      "window_construction": "U 0.68 SHGC 0.38 Simple Glazing Window",
+      "window_construction": "U 0.38 SHGC 0.38 Simple Glazing Window",
       "skylight_construction": "U 0.5 SHGC 0.36 Simple Glazing Skylight",
-      "operable_construction": "U 0.68 SHGC 0.38 Simple Glazing Window"
+      "operable_construction": "U 0.38 SHGC 0.38 Simple Glazing Window"
     },
     "door_set": {
       "type": "DoorConstructionSetAbridged",
@@ -558,9 +558,9 @@
     },
     "aperture_set": {
       "type": "ApertureConstructionSetAbridged",
-      "window_construction": "U 0.68 SHGC 0.38 Simple Glazing Window",
+      "window_construction": "U 0.38 SHGC 0.38 Simple Glazing Window",
       "skylight_construction": "U 0.5 SHGC 0.36 Simple Glazing Skylight",
-      "operable_construction": "U 0.68 SHGC 0.38 Simple Glazing Window"
+      "operable_construction": "U 0.38 SHGC 0.38 Simple Glazing Window"
     },
     "door_set": {
       "type": "DoorConstructionSetAbridged",
@@ -588,9 +588,9 @@
     },
     "aperture_set": {
       "type": "ApertureConstructionSetAbridged",
-      "window_construction": "U 0.68 SHGC 0.38 Simple Glazing Window",
+      "window_construction": "U 0.38 SHGC 0.38 Simple Glazing Window",
       "skylight_construction": "U 0.5 SHGC 0.36 Simple Glazing Skylight",
-      "operable_construction": "U 0.68 SHGC 0.38 Simple Glazing Window"
+      "operable_construction": "U 0.38 SHGC 0.38 Simple Glazing Window"
     },
     "door_set": {
       "type": "DoorConstructionSetAbridged",
@@ -618,9 +618,9 @@
     },
     "aperture_set": {
       "type": "ApertureConstructionSetAbridged",
-      "window_construction": "U 0.68 SHGC 0.4 Simple Glazing Window",
+      "window_construction": "U 0.36 SHGC 0.4 Simple Glazing Window",
       "skylight_construction": "U 0.5 SHGC 0.19 Simple Glazing Skylight",
-      "operable_construction": "U 0.68 SHGC 0.4 Simple Glazing Window"
+      "operable_construction": "U 0.36 SHGC 0.4 Simple Glazing Window"
     },
     "door_set": {
       "type": "DoorConstructionSetAbridged",
@@ -678,9 +678,9 @@
     },
     "aperture_set": {
       "type": "ApertureConstructionSetAbridged",
-      "window_construction": "U 0.68 SHGC 0.4 Simple Glazing Window",
+      "window_construction": "U 0.36 SHGC 0.4 Simple Glazing Window",
       "skylight_construction": "U 0.5 SHGC 0.19 Simple Glazing Skylight",
-      "operable_construction": "U 0.68 SHGC 0.4 Simple Glazing Window"
+      "operable_construction": "U 0.36 SHGC 0.4 Simple Glazing Window"
     },
     "door_set": {
       "type": "DoorConstructionSetAbridged",
@@ -708,9 +708,9 @@
     },
     "aperture_set": {
       "type": "ApertureConstructionSetAbridged",
-      "window_construction": "U 0.68 SHGC 0.4 Simple Glazing Window",
+      "window_construction": "U 0.36 SHGC 0.4 Simple Glazing Window",
       "skylight_construction": "U 0.5 SHGC 0.19 Simple Glazing Skylight",
-      "operable_construction": "U 0.68 SHGC 0.4 Simple Glazing Window"
+      "operable_construction": "U 0.36 SHGC 0.4 Simple Glazing Window"
     },
     "door_set": {
       "type": "DoorConstructionSetAbridged",
@@ -738,9 +738,9 @@
     },
     "aperture_set": {
       "type": "ApertureConstructionSetAbridged",
-      "window_construction": "U 0.68 SHGC 0.45 Simple Glazing Window",
+      "window_construction": "U 0.33 SHGC 0.45 Simple Glazing Window",
       "skylight_construction": "U 0.5 SHGC 0.27 Simple Glazing Skylight",
-      "operable_construction": "U 0.68 SHGC 0.45 Simple Glazing Window"
+      "operable_construction": "U 0.33 SHGC 0.45 Simple Glazing Window"
     },
     "door_set": {
       "type": "DoorConstructionSetAbridged",
@@ -798,9 +798,9 @@
     },
     "aperture_set": {
       "type": "ApertureConstructionSetAbridged",
-      "window_construction": "U 0.68 SHGC 0.45 Simple Glazing Window",
+      "window_construction": "U 0.33 SHGC 0.45 Simple Glazing Window",
       "skylight_construction": "U 0.5 SHGC 0.27 Simple Glazing Skylight",
-      "operable_construction": "U 0.68 SHGC 0.45 Simple Glazing Window"
+      "operable_construction": "U 0.33 SHGC 0.45 Simple Glazing Window"
     },
     "door_set": {
       "type": "DoorConstructionSetAbridged",
@@ -828,9 +828,9 @@
     },
     "aperture_set": {
       "type": "ApertureConstructionSetAbridged",
-      "window_construction": "U 0.68 SHGC 0.45 Simple Glazing Window",
+      "window_construction": "U 0.33 SHGC 0.45 Simple Glazing Window",
       "skylight_construction": "U 0.5 SHGC 0.27 Simple Glazing Skylight",
-      "operable_construction": "U 0.68 SHGC 0.45 Simple Glazing Window"
+      "operable_construction": "U 0.33 SHGC 0.45 Simple Glazing Window"
     },
     "door_set": {
       "type": "DoorConstructionSetAbridged",
@@ -858,9 +858,9 @@
     },
     "aperture_set": {
       "type": "ApertureConstructionSetAbridged",
-      "window_construction": "U 0.68 SHGC 0.45 Simple Glazing Window",
+      "window_construction": "U 0.29 SHGC 0.45 Simple Glazing Window",
       "skylight_construction": "U 0.5 SHGC 0.39 Simple Glazing Skylight",
-      "operable_construction": "U 0.68 SHGC 0.45 Simple Glazing Window"
+      "operable_construction": "U 0.29 SHGC 0.45 Simple Glazing Window"
     },
     "door_set": {
       "type": "DoorConstructionSetAbridged",
@@ -918,9 +918,9 @@
     },
     "aperture_set": {
       "type": "ApertureConstructionSetAbridged",
-      "window_construction": "U 0.68 SHGC 0.45 Simple Glazing Window",
+      "window_construction": "U 0.29 SHGC 0.45 Simple Glazing Window",
       "skylight_construction": "U 0.5 SHGC 0.39 Simple Glazing Skylight",
-      "operable_construction": "U 0.68 SHGC 0.45 Simple Glazing Window"
+      "operable_construction": "U 0.29 SHGC 0.45 Simple Glazing Window"
     },
     "door_set": {
       "type": "DoorConstructionSetAbridged",
@@ -948,9 +948,9 @@
     },
     "aperture_set": {
       "type": "ApertureConstructionSetAbridged",
-      "window_construction": "U 0.68 SHGC 0.45 Simple Glazing Window",
+      "window_construction": "U 0.29 SHGC 0.45 Simple Glazing Window",
       "skylight_construction": "U 0.5 SHGC 0.39 Simple Glazing Skylight",
-      "operable_construction": "U 0.68 SHGC 0.45 Simple Glazing Window"
+      "operable_construction": "U 0.29 SHGC 0.45 Simple Glazing Window"
     },
     "door_set": {
       "type": "DoorConstructionSetAbridged",

--- a/standards_update/_util/_construction_set.py
+++ b/standards_update/_util/_construction_set.py
@@ -132,8 +132,9 @@ ashrae_90_1_2013.construction_properties.json
             # get the exterior window construction
             win_type = 'Nonmetal framing (all)' if constr_type == 'WoodFramed' else \
                 'Metal framing (all other)'
-            if win_type == 'Metal framing (all other)' and 'ashrae_90_1_2019' in source_filename:
-                win_type = 'Metal framing (curtainwall/storefront)'
+            if win_type == 'Metal framing (all other)':
+                if 'ashrae_90_1_2019' in source_filename or 'ashrae_90_1_2016' in source_filename:
+                    win_type = 'Metal framing (curtainwall/storefront)'
             win_constr = extract_window_construction(data_store, c_zone, 'ExteriorWindow', win_type, 40)
             if win_constr is None:
                 win_constr = extract_construction(data_store, c_zone, 'ExteriorWindow', win_type)


### PR DESCRIPTION
It seems that we were pulling the wrong U-values in ASHRAE 90.1 2016 as well. More info is here:

https://discourse.ladybug.tools/t/default-ashrae-90-1-envelope-parameters-additional-options/16435